### PR TITLE
don't print logfile twice in dumpconfig

### DIFF
--- a/src/prtget.cpp
+++ b/src/prtget.cpp
@@ -2142,7 +2142,7 @@ void PrtGet::dumpConfig()
     cout.setf( ios::left, ios::adjustfield );
     cout.width( 20 );
     cout.fill( ' ' );
-    cout << "Pkgmk settings: " << m_config->logFilePattern() << endl;
+    cout << "Pkgmk settings:" << endl;
     cout.setf( ios::left, ios::adjustfield );
     cout.width( 20 );
     cout.fill( ' ' );


### PR DESCRIPTION
Looks like a copy-n-paste issue in commit
7c8a9b2ae5884cc8a15e31954768befdfd9442fe

The same value (m_config->logFilePattern()) is already printed out
several lines above (line 2130).
